### PR TITLE
Вывод самых популярных фильмов по жанру и годам

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -53,8 +53,10 @@ public class FilmController {
     }
 
     @GetMapping("/popular")
-    public Collection<Film> findPopular(@RequestParam(name = "count", defaultValue = "10") Integer count) {
-        return filmService.findPopular(count);
+    public Collection<Film> findPopular(@RequestParam(name = "count", defaultValue = "10") int count,
+                                        @RequestParam(name = "genreId", required = false) Long genreId,
+                                        @RequestParam(name = "year", required = false) Integer year) {
+        return filmService.findPopular(count, genreId, year);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -85,11 +85,10 @@ public class FilmService {
         filmStorage.deleteLike(filmId, userId);
     }
 
-    public Collection<Film> findPopular(Integer count) {
-        Collection<Film> films = filmStorage.findPopular(count);
+    public Collection<Film> findPopular(int count, Long genreId, Integer year) {
+        Collection<Film> films = filmStorage.findPopular(count, genreId, year);
         Map<Long, List<Genre>> genresByFilmId = genreStorage.findAllByFilms();
         films.forEach(film -> film.setGenres(genresByFilmId.getOrDefault(film.getId(), List.of())));
-
         return films;
     }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
@@ -15,7 +15,7 @@ public interface FilmDbStorage {
 
     Film update(Film film);
 
-    Collection<Film> findPopular(Integer count);
+    Collection<Film> findPopular(Integer count, Long genreId, Integer year);
 
     void addLike(long filmId, long userId);
 

--- a/src/test/java/ru/yandex/practicum/filmorate/FilmTests.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/FilmTests.java
@@ -358,7 +358,7 @@ public class FilmTests {
                         .isEqualToIgnoringWhitespace("[]"));
     }
 
-    @DisplayName("GET /films/popular. Получение популярных фильмов, count не указан")
+    @DisplayName("GET /films/popular. Получение популярных фильмов, параметры не указаны")
     @Test
     void findPopularFilmsNoCount() throws Exception {
         for (int i = 0; i < 12; i++) {
@@ -375,13 +375,41 @@ public class FilmTests {
                 .andExpect(jsonPath("$.length()").value(10));
     }
 
-    @DisplayName("GET /films/popular. Получение популярных фильмов, count указан")
+    @DisplayName("GET /films/popular. Получение популярных фильмов, count указан, жанр и год не указаны")
     @Order(11)
     @Test
     void findPopularFilms() throws Exception {
         mockMvc.perform(get("/films/popular?count=1").contentType("application/json"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1));
+    }
+
+    @DisplayName("GET /films/popular. Получение популярных фильмов, не найдено фильмов по параметрам")
+    @Test
+    @Order(12)
+    void findPopularFilmsNoResults() throws Exception {
+        mockMvc.perform(get("/films/popular?count=10&year=1900").contentType("application/json"))
+                .andExpect(status().isOk())
+                .andExpect(result -> assertThat(result.getResponse().getContentAsString())
+                        .isEqualToIgnoringWhitespace("[]"));
+    }
+
+    @DisplayName("GET /films/popular. Получение популярных фильмов с фильтром по жанру и году")
+    @Test
+    @Order(13)
+    void findPopularFilmsByGenreAndYear() throws Exception {
+        for (int i = 0; i < 12; i++) {
+            mockMvc.perform(post("/films").contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(film)));
+        }
+        for (int i = 0; i < 12; i++) {
+            String path = "/films/" + i + "/like/1";
+            mockMvc.perform(put(path).contentType("application/json"));
+        }
+
+        mockMvc.perform(get("/films/popular?count=10&genreId=1&year=2014").contentType("application/json"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(10));
     }
 
 }

--- a/src/test/java/ru/yandex/practicum/filmorate/storage/FilmDbStorageTests.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/storage/FilmDbStorageTests.java
@@ -133,7 +133,7 @@ public class FilmDbStorageTests {
     public void findPopular() {
         Film filmFromDB = filmDbStorage.add(film);
         filmDbStorage.addLike(filmFromDB.getId(), user.getId());
-        Collection<Film> populars2 = filmDbStorage.findPopular(1);
+        Collection<Film> populars2 = filmDbStorage.findPopular(1, null, null);
 
         assertThat(populars2.size()).isEqualTo(1);
 


### PR DESCRIPTION
🎦 Ветка для реализации задачи должна называться add-most-populars.

Описание задачи
Добавить возможность выводить топ-N фильмов по количеству лайков.

Фильтрация должна быть по двум параметрам.

По жанру.
За указанный год.
API
GET /films/popular?count={limit}&genreId={genreId}&year={year}

Возвращает список самых популярных фильмов указанного жанра за нужный год.